### PR TITLE
Batch all

### DIFF
--- a/src/impls/call-walk.ts
+++ b/src/impls/call-walk.ts
@@ -1,14 +1,15 @@
 import {EventCountingContext, MutableEventQueue, NestedCallNode, VisitingContext} from "../interfaces";
 import {CallVisitor, CallWalk, VisitedCall} from "../interfaces";
 import {SubstrateExtrinsic} from "@subql/types";
-import {BatchNode} from "./nodes/batch";
+import {BatchNode} from "./nodes/batch/batch";
 import {CreateEventQueue} from "./event-queue";
 import {EventQueue} from "../interfaces";
 import {CallBase} from "@polkadot/types/types/calls";
 import {AnyTuple} from "@polkadot/types-codec/types";
 import {Logger} from "pino"
+import {BatchAllNode} from "./nodes/batch/batchAll";
 
-const DefaultKnownNodes: NestedCallNode[] = [new BatchNode()]
+const DefaultKnownNodes: NestedCallNode[] = [new BatchNode(), new BatchAllNode()]
 
 export function CreateCallWalk(
     nodes: NestedCallNode[] = DefaultKnownNodes,
@@ -61,6 +62,7 @@ class CallWalkImpl implements CallWalk {
 
             let context: VisitingContext = {
                 visitor: visitor,
+                callSucceeded: visitedCall.success,
                 eventQueue: eventQueue,
                 origin: visitedCall.origin,
                 extrinsic: visitedCall.extrinsic,
@@ -81,7 +83,7 @@ class CallWalkImpl implements CallWalk {
     private endExclusiveToSkipInternalEvents(
         call: CallBase<AnyTuple>,
         eventQueue: EventQueue,
-        endExclusive: number
+        endExclusive: number,
     ): number {
         let nestedNode = this.findNestedNode(call)
 

--- a/src/impls/nodes/batch/batchAll.ts
+++ b/src/impls/nodes/batch/batchAll.ts
@@ -1,0 +1,80 @@
+import {EventCountingContext, NestedCallNode, VisitingContext} from "../../../interfaces";
+import {VisitedCall} from "../../../interfaces";
+import {CallBase} from "@polkadot/types/types/calls";
+import {AnyTuple} from "@polkadot/types-codec/types";
+import {IVec} from "@polkadot/types-codec/types/interfaces";
+import {BatchCompleted, ItemCompleted, takeNestedBatchItemEvents} from "./types";
+
+const CompletionEvents = [BatchCompleted]
+const ItemEvents = [ItemCompleted]
+
+export class BatchAllNode implements NestedCallNode {
+
+    canVisit(call: CallBase<AnyTuple>): boolean {
+        return call.section == "utility" && call.method == "batchAll"
+    }
+
+    endExclusiveToSkipInternalEvents(call: CallBase<AnyTuple>, context: EventCountingContext): number {
+        const innerCalls = call.args[0] as IVec<CallBase<AnyTuple>>
+        let endExclusive = context.endExclusive
+
+        // Safe since `endExclusiveToSkipInternalEvents` should not be called on failed items
+        const indexOfCompletedEvent = context.eventQueue.indexOfLast(CompletionEvents, endExclusive)
+        if (indexOfCompletedEvent == undefined) {
+           throw Error("endExclusiveToSkipInternalEvents called for failed batchAll")
+        }
+        endExclusive = indexOfCompletedEvent
+
+        // bathAll completed means all calls have completed
+        innerCalls.forEach((innerCall) => {
+            let itemIdx = context.eventQueue.indexOfLast(ItemEvents, endExclusive)
+            endExclusive = context.endExclusiveToSkipInternalEvents(innerCall, itemIdx)
+        })
+
+        return endExclusive
+    }
+
+    async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+        let innerCalls = call.args[0] as IVec<CallBase<AnyTuple>>
+
+        context.logger.info(`Visiting utility.batchAll with ${innerCalls.length} inner calls`)
+
+        if (context.callSucceeded) {
+            context.logger.info(`BatchAll succeeded`)
+        } else  {
+            context.logger.info(`BatchAll failed`)
+        }
+
+        let visitedSubItems: VisitedCall[] = new Array(innerCalls.length)
+        for (let i = innerCalls.length - 1; i >= 0; i--) {
+            if (context.callSucceeded) {
+                const alNestedEvents = takeNestedBatchItemEvents(context, innerCalls[i])
+
+                visitedSubItems[i] = {
+                    call: innerCalls[i],
+                    success: true,
+                    events: alNestedEvents,
+                    origin: context.origin,
+                    extrinsic: context.extrinsic,
+                }
+            } else {
+                visitedSubItems[i] = {
+                    call: innerCalls[i],
+                    success: false,
+                    events: [],
+                    origin: context.origin,
+                    extrinsic: context.extrinsic,
+                }
+            }
+        }
+
+        for (let i = 0; i < visitedSubItems.length; i++) {
+            const visitedCall = visitedSubItems[i]
+            let events = visitedCall.events.map((e) => e.method)
+
+            context.logger.info(`BatchAll - visiting batch item at ${i}, item events: ${events}`)
+
+            await context.nestedVisit(visitedCall);
+        }
+    }
+}

--- a/src/impls/nodes/batch/types.ts
+++ b/src/impls/nodes/batch/types.ts
@@ -1,0 +1,22 @@
+import {VisitingContext} from "../../../interfaces";
+import {CallBase} from "@polkadot/types/types/calls";
+import {AnyTuple} from "@polkadot/types-codec/types";
+
+export const BatchCompleted = api.events.utility.BatchCompleted
+export const BatchInterrupted = api.events.utility.BatchInterrupted
+export const ItemCompleted = api.events.utility.ItemCompleted
+
+export function takeNestedBatchItemEvents(context: VisitingContext, call: CallBase<AnyTuple>) {
+    context.eventQueue.popFromEnd(ItemCompleted);
+
+    const internalEventsEndExclusive = context.endExclusiveToSkipInternalEvents(call)
+
+    // internalEnd is exclusive => it holds index of last internal event
+    // thus, we delete them inclusively
+    const someOfNestedEvents = context.eventQueue.takeAllAfterInclusive(internalEventsEndExclusive)
+
+    // now it is safe to go until ItemCompleted since we removed all potential nested events above
+    const remainingNestedEvents = context.eventQueue.takeTail(ItemCompleted)
+
+    return [...remainingNestedEvents, ...someOfNestedEvents]
+}

--- a/src/interfaces/nested-call-node.ts
+++ b/src/interfaces/nested-call-node.ts
@@ -13,6 +13,7 @@ export interface NestedCallNode {
      * For example, utility.batch supposed to skip BatchCompleted/BatchInterrupted and all ItemCompleted events
      * This function is used by `visit` to skip internal events of nested nodes of the same type (batch inside batch or proxy inside proxy)
      * so they wont interfere
+     * Should not be called on failed nested calls since they emit no events and its trivial to proceed
      */
     endExclusiveToSkipInternalEvents(call: CallBase<AnyTuple>, context: EventCountingContext): number
 
@@ -22,6 +23,8 @@ export interface NestedCallNode {
 export interface VisitingContext {
 
     origin: string
+
+    callSucceeded: boolean
 
     extrinsic: SubstrateExtrinsic
 


### PR DESCRIPTION
Implement batch all
Make nodes aware of what parent thinks regarding their success (in case they have been reverted by failed execution of parent)

Tested on

https://kusama.subscan.io/extrinsic/17762253-2 - batchAll with nested batches
https://kusama.subscan.io/extrinsic/17762026-5 - failed batchAll with nested batches
