### PR TITLE
fix: batch_all success handler

### DIFF
--- a/src/impls/nodes/utility/batchAll.ts
+++ b/src/impls/nodes/utility/batchAll.ts
@@ -54,21 +54,13 @@ export class BatchAllNode implements NestedCallNode {
       for (let i = innerCalls.length - 1; i >= 0; i--) {
         let innerCall = innerCalls[i];
         if (!innerCall) continue;
-
-        // Check if this item succeeded or failed by looking at the event
-        const itemEvent = context.eventQueue.takeFromEnd(ItemCompleted, ItemFailed);
-        let itemSuccess = false;
-        
-        if (itemEvent) {
-          itemSuccess = ItemCompleted?.is(itemEvent) || false;
-        }
-
-        const alNestedEvents = takeCompletedBatchItemEvents(context, innerCall);
+        const itemEvent = context.eventQueue.takeFromEnd(...ItemEvents);
+        const itemSuccess = !!(itemEvent && ItemCompleted?.is(itemEvent));
 
         visitedSubItems[i] = {
           call: innerCall,
           success: itemSuccess,
-          events: alNestedEvents,
+          events: takeCompletedBatchItemEvents(context, innerCall),
           origin: context.origin,
           extrinsic: context.extrinsic,
         };


### PR DESCRIPTION
That PR fixes problem, when batchAll on first layer is success, but all nested - failed, example:
https://westend.subscan.io/extrinsic/6624751-2

Problem before that fix:
<img width="1220" height="439" alt="Screenshot 2025-09-23 at 12 00 58" src="https://github.com/user-attachments/assets/caf55c3d-a6e2-4e71-b59f-b4243516c556" />

After fix:
<img width="1624" height="1056" alt="Screenshot 2025-09-23 at 11 35 56" src="https://github.com/user-attachments/assets/12177331-d722-41e3-a045-5953d8acba71" />

