### PR TITLE
use ignoreChecksum address decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ Thumbs.db
 *.flv
 *.mov
 *.wmv
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subquery-call-visitor",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Easy traversing of nested Substrate calls in your SubQuery indexer",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/impls/nodes/multisig/common.ts
+++ b/src/impls/nodes/multisig/common.ts
@@ -1,6 +1,6 @@
 import { IVec } from '@polkadot/types-codec/types/interfaces';
 import { AccountId } from '@polkadot/types/interfaces/runtime/types';
-import { encodeMultiAddress, ethereumEncode, isEthereumAddress, createKeyMulti } from '@polkadot/util-crypto';
+import { isEthereumAddress, ethereumEncode, createKeyMulti, decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 
 export const MultisigExecuted = api.events?.multisig?.MultisigExecuted;
 export const MultisigApproval = api.events?.multisig?.MultisigApproval;
@@ -11,8 +11,19 @@ export function generateMultisigAddress(origin: string, otherSignatories: IVec<A
   const allAddresses = otherSignatoriesAddresses.concat(origin);
 
   if (isEthereumAddress(origin)) {
-    return ethereumEncode(createKeyMulti(allAddresses, threshold).slice(0, 20));
+    return ethereumEncode(
+      createKeyMulti(
+        allAddresses.map(a => decodeAddress(a, true)),
+        threshold,
+      ).slice(0, 20),
+    );
   } else {
-    return encodeMultiAddress(allAddresses, threshold, api.registry.chainSS58);
+    return encodeAddress(
+      createKeyMulti(
+        allAddresses.map(a => decodeAddress(a, true)),
+        threshold,
+      ),
+      api.registry.chainSS58,
+    );
   }
 }

--- a/src/impls/nodes/utility/asDerivative.ts
+++ b/src/impls/nodes/utility/asDerivative.ts
@@ -2,7 +2,7 @@ import { AnyEvent, EventCountingContext, NestedCallNode, VisitedCall, NodeContex
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
 import { INumber } from '@polkadot/types-codec/types/interfaces';
-import { encodeDerivedAddress } from '@polkadot/util-crypto';
+import { decodeAddress, encodeAddress, createKeyDerived } from '@polkadot/util-crypto';
 
 export class AsDerivativeNode implements NestedCallNode {
   canVisit(call: CallBase<AnyTuple>): boolean {
@@ -69,6 +69,6 @@ export class AsDerivativeNode implements NestedCallNode {
   private extractInnerOrigin(call: CallBase<AnyTuple>, parentOrigin: string): string {
     const index = call.args[0] as INumber;
 
-    return encodeDerivedAddress(parentOrigin, index.toNumber());
+    return encodeAddress(createKeyDerived(decodeAddress(parentOrigin, true), index.toNumber()));
   }
 }


### PR DESCRIPTION
Fix: Use `ignoreChecksum` flag when decoding addresses in SubQuery sandbox

**Problem:**
In SubQuery's webpack sandbox environment, `blake2b` (used for address checksum verification) may not work correctly because wasm-crypto can fail to fully initialize. This causes `Invalid decoded address checksum` errors when processing blocks containing `asDerivative` or multisig calls.

**Changes:**
- `asDerivative.ts`: Replaced `encodeDerivedAddress(parentOrigin, index)` with `encodeAddress(createKeyDerived(decodeAddress(parentOrigin, true), index))`
- `common.ts` (multisig): Replaced `encodeMultiAddress(allAddresses, threshold, ss58)` with `encodeAddress(createKeyMulti(allAddresses.map(a => decodeAddress(a, true)), threshold), ss58)`, and similarly for the Ethereum path.

**Why this is safe:**
- The `true` flag passed to `decodeAddress` only skips the checksum verification step — it does not alter how the address bytes are decoded or encoded.
- All addresses reaching these code paths originate from extrinsic signatures or on-chain storage, meaning they have already been validated by the Substrate runtime. The checksum check is redundant here.
- `createKeyDerived` and `createKeyMulti` are the same internal functions that `encodeDerivedAddress` and `encodeMultiAddress` use under the hood — the only difference is that we now control the `decodeAddress` call and can pass `ignoreChecksum`.
- The output addresses are byte-identical to what the original helper functions would produce.